### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.pdf,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,5 +2,5 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = .git*,*.pdf,.codespellrc
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+ignore-regex = \bnAm\b
+ignore-words-list = trough

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

And congrats -- ATM it found no typos whatsoever, so your repo is quite clean in that regard, and `codespell` would help to keep it such ;-)